### PR TITLE
Init GoogleTranslate with up-to-date languages

### DIFF
--- a/src/google.ts
+++ b/src/google.ts
@@ -3,130 +3,31 @@ import { ITranslate } from "./translate.interface";
 //const {Translate} = require('@google-cloud/translate').v2;
 import { Translate } from "@google-cloud/translate/build/src/v2";
 import { Util } from "./util";
-const supportedLanguages = [
-  "af",
-  "sq",
-  "am",
-  "ar",
-  "hy",
-  "az",
-  "eu",
-  "be",
-  "bn",
-  "bs",
-  "bg",
-  "ca",
-  "ceb",
-  "zh-CN",
-  "zh",
-  "zh-TW",
-  "co",
-  "hr",
-  "cs",
-  "da",
-  "nl",
-  "en",
-  "eo",
-  "et",
-  "fi",
-  "fr",
-  "fy",
-  "gl",
-  "ka",
-  "de",
-  "el",
-  "gu",
-  "ht",
-  "ha",
-  "haw",
-  "he",
-  "iw",
-  "hi",
-  "hmn",
-  "hu",
-  "is",
-  "ig",
-  "id",
-  "ga",
-  "it",
-  "ja",
-  "jv",
-  "kn",
-  "kk",
-  "km",
-  "rw",
-  "ko",
-  "ku",
-  "ky",
-  "lo",
-  "lv",
-  "lt",
-  "lb",
-  "mk",
-  "mg",
-  "ms",
-  "ml",
-  "mt",
-  "mi",
-  "mr",
-  "mn",
-  "my",
-  "ne",
-  "no",
-  "ny",
-  "or",
-  "ps",
-  "fa",
-  "pl",
-  "pt",
-  "pa",
-  "ro",
-  "ru",
-  "sm",
-  "gd",
-  "sr",
-  "st",
-  "sn",
-  "sd",
-  "si",
-  "sk",
-  "sl",
-  "so",
-  "es",
-  "su",
-  "sw",
-  "sv",
-  "tl",
-  "tg",
-  "ta",
-  "tt",
-  "te",
-  "th",
-  "tr",
-  "tk",
-  "uk",
-  "ur",
-  "ug",
-  "uz",
-  "vi",
-  "cy",
-  "xh",
-  "yi",
-  "yo",
-  "zu",
-];
+
+async function getSupportedLanguages(translate: Translate): Promise<string[]> {
+  const [languages] = await translate.getLanguages();
+  return languages.map((language, _index, _array) => language.code.toLowerCase());
+}
+
 export class GoogleTranslate implements ITranslate {
   private apikey: string;
   private googleTranslate: Translate;
+  private supportedLanguages: string[] = [];
 
-  constructor(apikey: string) {
+  constructor(apikey: string, googleTranslate?: Translate, supportedLanguages: string[] = []) {
     this.apikey = apikey;
-    this.googleTranslate = new Translate({ key: this.apikey });
-    // this.googleTranslate.getSupportedLanguages();
+    this.googleTranslate = googleTranslate ?? new Translate({ key: this.apikey });
+    this.supportedLanguages = supportedLanguages;
+  }
+
+  static async initialize(apiKey: string): Promise<GoogleTranslate> {
+    const googleTranslate = new Translate({ key: apiKey });
+    const supportedLanguages = await getSupportedLanguages(googleTranslate);
+    return new GoogleTranslate(apiKey, googleTranslate, supportedLanguages);
   }
 
   isValidLocale(targetLocale: string): boolean {
-    return supportedLanguages.includes(targetLocale);
+    return this.supportedLanguages.includes(targetLocale);
   }
 
   async translateText(

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -30,7 +30,7 @@ export async function translate(
   let translateEngine: ITranslate;
 
   if (config.translationKeyInfo.kind === "google") {
-    translateEngine = new GoogleTranslate(config.translationKeyInfo.apiKey);
+    translateEngine = await GoogleTranslate.initialize(config.translationKeyInfo.apiKey);
   } else if (config.translationKeyInfo.kind === "aws") {
     translateEngine = new AWSTranslate(
       config.translationKeyInfo.accessKeyId,


### PR DESCRIPTION
Updates the GoogleTranslate class to be initialised with the available languages provided by `.getLanguages()` from the Google translate library, instead of a hard coded list.

Let me know if you have any suggested changes.