### PR TITLE
Hotfix/deepL response access breaking typo

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,10 +1,10 @@
-# About  project
+# About project
 
 This project is used in, (and refactored from) excellent vs code extension
 Auto Translate JSON
 <https://marketplace.visualstudio.com/items?itemName=JeffJorczak.auto-translate-json>
 
-It opens posibility to use Auto Taransation JSON
+It opens posibility to use Auto Translation JSON
 not just in vs code but as a library and command line interface
 
 ## Use as library
@@ -42,17 +42,17 @@ do not forget to set translation engine parameters in environment variables or .
 node node_modules\auto-translate-json-library\index.js --pivotTranslation=./translations/en.json
 ```
 
-if you clone repo  you can use the following commands
+if you clone repo you can use the following commands
 
 ```shell
 npm i
 npm run build
-node .\build\src\index.js --pivotTranslation=./tests/translations/en.json  
+node .\build\src\index.js --pivotTranslation=./tests/translations/en.json
 ```
 
 ## CLI PARAMETERS
 
-``` config
+```config
 mode,
 file or folder,
 default is file
@@ -131,7 +131,7 @@ ATJ_IGNORE_PREFIX=
 
 You can also use .env file to store environment variables
 
-There is also improved version of CLI  (since version 1.3.2) for example:
+There is also improved version of CLI (since version 1.3.2) for example:
 
 ```shell
 npm install -g auto-translate-library
@@ -143,3 +143,7 @@ You can also use it with npx
 ```shell
 npx auto-translate-library tests/translations/en.json -e google -m file
 ```
+
+### Debug
+
+npm run debug

--- a/README.MD
+++ b/README.MD
@@ -145,5 +145,6 @@ npx auto-translate-library tests/translations/en.json -e google -m file
 ```
 
 ### Debug
-
-npm run debug
+ 1. Create .env file in main folder with the desired key/keys from # ENVIRONMENT VARIABLES 
+ 2. Add also in .env  source locale "ATJ_SOURCE_LOCALE=en" to test from en
+ 3. npm run debug

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-translate-json-library",
-  "version": "1.3.1",
+  "version": "1.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-translate-json-library",
-      "version": "1.3.1",
+      "version": "1.3.4",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-translate": "3.421.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "prepare": "tsc",
     "build": "tsc",
+    "build:run": "ts-node ./build/src/index.js --pivotTranslation=./tests/translations/en.json",
+    "debug": "ts-node src/index.ts --pivotTranslation=./tests/translations/en.json",
     "lint": "biome check ./src",
     "lint-fix": "biome check ./src --apply",
     "lint-fix-all": "biome check --apply-unsafe ./src",

--- a/src/deepl.ts
+++ b/src/deepl.ts
@@ -69,7 +69,7 @@ export class DeepLTranslate implements ITranslate {
       responseType: "json",
     });
 
-    result = response.translations[1].text;
+    result = response.data.translations[0].text;
 
     result = Util.replaceArgumentsWithNumbers(args, result);
 


### PR DESCRIPTION
This is a small hotfix, for a breaking DeepL response access typo.

<img src="https://github.com/topce/auto-translate-json-library/assets/76633311/68f327bb-6920-4310-8ac7-ed0b57a27279" width="400">